### PR TITLE
Fix #30: Add EWC Consortium trust list URL to metadata

### DIFF
--- a/last_updated.json
+++ b/last_updated.json
@@ -6,5 +6,5 @@
   "vct_values":"1768455979",
   "add_cards_items":"1771004585",
   "wallet_provider":"1775152842",
-  "trust_list":"1783530223"
+  "trust_list":"1783579858"
 }

--- a/trust_list.json
+++ b/trust_list.json
@@ -7,6 +7,10 @@
     {
       "name": "NXD",
       "url": "https://raw.githubusercontent.com/NXD-Foundation/nxd-trust-list/refs/heads/main/NXD-TL.xml"
+    },
+    {
+      "name": "EWC-Consortium",
+      "url": "https://ewc-consortium.github.io/ewc-trust-list/EWC-TL"
     }
   ]
 }


### PR DESCRIPTION
- Add EWC Consortium trust list URL to trust_list.json
- Update trust_list last_updated_time in last_updated.json