### PR TITLE
Add trust list service endpoints to metadata

### DIFF
--- a/last_updated.json
+++ b/last_updated.json
@@ -6,5 +6,5 @@
   "vct_values":"1768455979",
   "add_cards_items":"1771004585",
   "wallet_provider":"1775152842",
-  "trust_list":"1783579858"
+  "trust_list":"1784545549"
 }

--- a/trust_list.json
+++ b/trust_list.json
@@ -12,5 +12,25 @@
       "name": "EWC-Consortium",
       "url": "https://ewc-consortium.github.io/ewc-trust-list/EWC-TL"
     }
-  ]
+  ],
+  "trust_list_service": {
+    "staging": {
+      "base_url": "https://trustlist-test.eubw.dev",
+      "endpoints": {
+        "nonce": "/trust-list/nonce",
+        "lookup": "/trust-list/lookup"
+      },
+      "last_updated_time": 1784545549,
+      "reload_required": false
+    },
+    "production": {
+      "base_url": "https://trustlist-test.eubw.dev",
+      "endpoints": {
+        "nonce": "/trust-list/nonce",
+        "lookup": "/trust-list/lookup"
+      },
+      "last_updated_time": 1784545549,
+      "reload_required": false
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add `trust_list_service` config to `trust_list.json` with staging and production environments
- Each environment defines `base_url` (`https://trustlist-test.eubw.dev`), `nonce` and `lookup` endpoints, `last_updated_time`, and `reload_required` flag
- Bump `trust_list` timestamp in `last_updated.json`

## Notes
- Production currently points to the same test base URL (`trustlist-test.eubw.dev`) as staging